### PR TITLE
Fix maven perform plugin errors due to javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
-        <version>9</version>
+        <version>12</version>
     </parent>
 
     <artifactId>alfresco-greenmail</artifactId>


### PR DESCRIPTION
- Bumped `alfresco-super-pom` to `12` to generate Java 8 compatible byte code