### PR TITLE
Disable javadoc lint check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 
     <properties>
         <licenseName>community</licenseName>
+        <additionalparam>-Xdoclint:none</additionalparam>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- Disable javadoc lint check and revert to 6.2-SNAPSHOT to maintain release sequence